### PR TITLE
All status now cached, unless you use testing_control.values.bypass_c…

### DIFF
--- a/src/server/electric/rest_interface.py
+++ b/src/server/electric/rest_interface.py
@@ -66,6 +66,7 @@ class UnifiedResource(Resource):
 
         return obj
 
+
 class DialogCloseResource(Resource):
     def put(self, channel_id):
         channel = int(channel_id)

--- a/src/server/electric/worker/cache.py
+++ b/src/server/electric/worker/cache.py
@@ -1,0 +1,77 @@
+import time, logging
+
+from electric import testing_control as testing_control
+
+logger = logging.getLogger('electric.worker.router')
+
+#
+# class CachedValue(object):
+#     cache_expiry_seconds = 1.0
+#
+#     def __init__(self, v = None):
+#         super(CachedValue, self).__init__()
+#         self.updated = None
+#         self.attr = v
+#
+#     def set_stale(self):
+#         self.updated = None
+#
+#     @property
+#     def value(self):
+#         return self.attr
+#
+#     @value.setter
+#     def value(self, new_value):
+#         self.attr = new_value
+#         self.updated = time.time()
+#
+#     @property
+#     def is_stale(self):
+#         if testing_control.values.bypass_caches:
+#             return True
+#
+#         if self.updated is None:
+#             return True
+#
+#         right_now = time.time()
+#         difference = right_now - self.updated
+#
+#         return difference >= CachedValue.cache_expiry_seconds
+#
+
+cache = {
+    "device_id": None,
+    "device_info": None,
+    "channel": [ None, None ]
+}
+
+
+def reset_caches():
+    global cache
+    cache = {
+        "device_id": None,
+        "device_info": None,
+        "channel": [ None, None ]
+    }
+
+
+def get_device_info_cached():
+    return cache["device_info"]
+
+
+def set_device_info_cached(device_info):
+    cache["device_info"] = device_info
+    logging.debug("stored device_info")
+
+
+def get_channel_status_cached(channel):
+    channel = int(channel)
+    assert (channel == 0 or channel == 1)
+    return cache["channel"][channel]
+
+
+def set_channel_status(channel, status):
+    channel = int(channel)
+    assert (channel == 0 or channel == 1)
+    cache["channel"][channel] = status
+    logging.debug("stored channel {0} status".format(channel))

--- a/src/server/electric/worker/comms_layer.py
+++ b/src/server/electric/worker/comms_layer.py
@@ -335,9 +335,6 @@ class ChargerCommsManager(object):
 
         modbus_response = self.charger.modbus_write_registers(0x8000 + 2, values_list)
 
-        # status = self.get_device_info().get_status(channel_number)
-        # logger.info("Device status: {0}".format(status.to_native()))
-
         # If showing a dialog, or have error, try to clear the dialog
         # This also works to close the presets listing, if that is open
         # if status.dlg_box_status or status.err:
@@ -361,8 +358,7 @@ class ChargerCommsManager(object):
         # logger.info("Sending run_op to channel {2}: op {0}, preset: {1}".format(operation, preset_memory_slot_index, channel_number))
         self.charger.modbus_write_registers(0x8000, values_list)
 
-        return self.get_device_info().get_status(channel_number)
-
+        return True
 
     def measure_ir(self, channel_number):
         channel_number = min(1, max(0, channel_number))
@@ -398,4 +394,4 @@ class ChargerCommsManager(object):
         # Restore original preset in RAM (possibly not actually necessary)
         # self.save_preset_to_memory_slot(original_preset, original_preset.index, write_to_flash=False, verify_write=False)
 
-        return self.get_device_info().get_status(channel_number)
+        return True

--- a/src/server/electric/worker/tests/test_cached_values.py
+++ b/src/server/electric/worker/tests/test_cached_values.py
@@ -1,7 +1,7 @@
 import logging, time
 import unittest
 
-from electric.worker.router import CachedValue, cached_channel_status
+from electric.worker.cache import CachedValue, cached_channel_status
 from electric.worker.router import route_message
 
 logger = logging.getLogger(__name__)

--- a/src/server/electric/worker/tests/test_modbus_usb.py
+++ b/src/server/electric/worker/tests/test_modbus_usb.py
@@ -104,6 +104,7 @@ class TestGatewayCommunications(unittest.TestCase):
 
     def test_status_contains_num_channels(self):
         obj = comms
+        testing_control.values.bypass_caches = True
         status = obj.get_device_info()
         self.assertIsNotNone(status)
         self.assertEqual(status.channel_count, 2)
@@ -120,6 +121,7 @@ class TestGatewayCommunications(unittest.TestCase):
 
     def test_number_of_channels(self):
         obj = comms
+        testing_control.values.bypass_caches = True
         resp = obj.get_device_info()
         self.assertTrue(resp.cell_count >= 6)
 

--- a/src/server/electric/worker/tests/test_models.py
+++ b/src/server/electric/worker/tests/test_models.py
@@ -3,6 +3,7 @@ import unittest
 
 from schematics.exceptions import ModelValidationError
 from electric.models import DeviceInfo, DeviceInfoStatus, PresetIndex, Preset
+from electric.worker.cache import reset_caches, get_device_info_cached, get_channel_status_cached, set_channel_status, set_device_info_cached
 
 logger = logging.getLogger("electric.app.test.{0}".format(__name__))
 
@@ -15,6 +16,26 @@ class TestDeviceStatusInfoSerialization(unittest.TestCase):
         self.assertNotIn("value", prim)
         self.assertEqual(status.run, 1)
         self.assertEqual(status.err, 0)
+
+    def test_can_fetch_device_info_when_its_not_been_set(self):
+        reset_caches()
+        self.assertIsNone(get_device_info_cached())
+        self.assertIsNone(get_channel_status_cached(0))
+        self.assertIsNone(get_channel_status_cached(1))
+
+        score = { "them": 1, "me": None }
+        set_device_info_cached(score)
+
+        self.assertEqual(get_device_info_cached(), score)
+
+        set_channel_status(0, score)
+        self.assertEqual(get_channel_status_cached(0), score)
+        self.assertIsNone(get_channel_status_cached(1))
+
+        set_channel_status(0, None)
+        set_channel_status(1, score)
+        self.assertEqual(get_channel_status_cached(1), score)
+        self.assertIsNone(get_channel_status_cached(0))
 
     def test_deviceinfostatus_json_keys(self):
         status = DeviceInfoStatus()

--- a/src/server/electric/worker/worker.py
+++ b/src/server/electric/worker/worker.py
@@ -1,10 +1,11 @@
-import zmq, logging, sys, os
+import zmq, logging, sys, os, threading, datetime, time
 import zmq.utils.win32
 
 from comms_layer import ChargerCommsManager
 import electric.testing_control as testing_control
 
 from router import route_message
+from cache import set_channel_status, set_device_info_cached
 
 logger = logging.getLogger('electric.worker')
 
@@ -13,12 +14,62 @@ ctx = zmq.Context()
 socket = ctx.socket(zmq.REP)
 
 listen_on = os.environ.get("ELECTRIC_WORKER_LISTEN", "tcp://0.0.0.0:5001")
-socket.bind(listen_on)
-
-poller = zmq.Poller()
-poller.register(socket, zmq.POLLIN)
 
 charger = ChargerCommsManager()
+lock = threading.Lock()
+
+
+def setup_zeromq():
+    socket.bind(listen_on)
+    global poller
+    poller = zmq.Poller()
+    poller.register(socket, zmq.POLLIN)
+
+
+
+class StatusThread(threading.Thread):
+    def __init__(self, charger):
+        super(StatusThread, self).__init__(name="Status Reader")
+        self.daemon = True
+        self.charger = charger
+        self.keep_going = True
+
+    def run(self):
+        while self.keep_going:
+            # fetch charger status, channel 0/1 and store
+            # pause to breath - it is after all only good form
+            try:
+                with lock:
+                    start_time = datetime.datetime.now()
+
+                    device_info = self.charger.get_device_info()
+                    if device_info and self.keep_going:
+                        set_device_info_cached(device_info)
+
+                        for channel in range(0, device_info.channel_count):
+                            channel_status = self.charger.get_channel_status(channel, device_info.device_id)
+                            if channel == 0 or channel == 1:
+                                set_channel_status(channel, channel_status)
+                            if not self.keep_going:
+                                return
+
+                    end_time = datetime.datetime.now()
+
+                # wait for about 500ms minus the time it took, in other words - try to update these twice a second
+                elapsed_ms = end_time - start_time
+                wait_seconds = 0.5 - elapsed_ms.total_seconds()
+                if wait_seconds > 0:
+                    time.sleep(wait_seconds)
+                else:
+                    # well, it too longer than 500ms, so pause a wee bit more (>700 ms total - yeah, a stab in the dark)
+                    time.sleep(0.2)
+
+            except Exception, e:
+                logger.error("exception while reading status/channel info: {0}".format(e))
+                time.sleep(5)
+
+
+fetcher = StatusThread(charger)
 
 
 def stop_application():
@@ -27,11 +78,21 @@ def stop_application():
     sys.exit(0)
 
 
-def run_worker():
-    logging.basicConfig(level=logging.WARN, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
+def start_fetcher_thread():
+    """Starts a thread that requests /status and /channel information on a periodic basis and places it in a cache"""
+    fetcher.start()
+    logger.info("started fetcher thread")
 
+
+def stop_fetcher_thread():
+    """Stops the fetcher thread - its just good form dear boy"""
+    fetcher.keep_going = False
+    fetcher.join()
+
+
+def run_worker():
     with zmq.utils.win32.allow_interrupt(stop_application):
-        logger.warn("iCharger USB reader worker listening on: %s", listen_on)
+        logger.info("iCharger USB reader worker listening on: %s", listen_on)
 
         try:
             while True:
@@ -49,29 +110,39 @@ def run_worker():
                         if "args" in message:
                             args = message["args"]
 
-                        if "testing-control" in message:
-                            testing_control.values = message["testing-control"]
-
-                        message_log = "message: {0}/{1} with args: {2}".format(message["tag"], method, args)
-
                         try:
-                            logger.info("executing message: {0}".format(message_log))
-                            message["response"] = route_message(charger, method, args)
-                        except Exception, e:
-                            logger.error("EXCEPTION during routing/execution for : {0}, {1}".format(message_log, e))
-                            message["raises"] = e
+                            with lock:
+                                if "testing-control" in message:
+                                    testing_control.values = message["testing-control"]
 
-                        try:
-                            # potentially; the receiver goes away - before we are finished sending -
-                            logger.info("sending response for: {0}".format(message_log))
-                            socket.send_pyobj(message)
-                            logger.info("sent response for: {0}".format(message_log))
-                        except Exception, e:
-                            logger.error("unable to send response for {0}, {1}".format(message_log, e))
+                                message_log = "message: {0}/{1} with args: {2}".format(message["tag"], method, args)
+
+                                try:
+                                    logger.info("executing {0}".format(message_log))
+                                    message["response"] = route_message(charger, method, args)
+                                except Exception, e:
+                                    logger.error("EXCEPTION during routing of {0}, {1}".format(message_log, e))
+                                    message["raises"] = e
+
+                                try:
+                                    # potentially; the receiver goes away - before we are finished sending -
+                                    logger.info("sending response for {0}".format(message_log))
+                                    socket.send_pyobj(message)
+                                    logger.info("sent response for {0}".format(message_log))
+                                except Exception, e:
+                                    logger.error("unable to send response for {0}, {1}".format(message_log, e))
+
+                        finally:
+                            testing_control.values.reset()
 
         except KeyboardInterrupt:
-            logger.info("Ctrl-C interrupted worker - aborting...")
+            logger.warn("Ctrl-C interrupted worker...")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
+
+    setup_zeromq()
+    start_fetcher_thread()
     run_worker()
+    stop_fetcher_thread()

--- a/src/server/electric/zmq_marshall.py
+++ b/src/server/electric/zmq_marshall.py
@@ -105,14 +105,13 @@ class ZMQCommsManager(object):
         """
         return self._send_message_get_response("get_device_info")
 
-    def get_channel_status(self, channel, device_id=None):
+    def get_channel_status(self, channel):
         """"
         Returns the following information from the iCharger, known as the 'channel input read only' message:
         :return: ChannelStatus instance
         """
         return self._send_message_get_response("get_channel_status", {
-            "channel": channel,
-            "device_id": device_id
+            "channel": channel
         })
 
     def get_control_register(self):


### PR DESCRIPTION
…aches = True before making the ZMQ call.